### PR TITLE
update icons (Material Icons -> Material Symbols)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons%7CMaterial+Icons+Outlined" rel="stylesheet">
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@24,400,1,0" />
     <title>firebase-vue3-startup-kit</title>
   </head>
   <body>

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -5,7 +5,7 @@
         <div class="bg-blue-300">
           <div class="relative flex items-center">
             <div @click="toggleMenu()" class="inline-flex h-14 w-14 flex-shrink-0 cursor-pointer items-center justify-center">
-              <span class="material-icons text-warmgray-900 text-opacity-60">menu</span>
+              <span class="material-symbols-outlined text-warmgray-900 text-opacity-60">menu</span>
             </div>
             <div class="w-full items-center">Firebase Vue3 kit</div>
             <div v-show="menu" class="fixed top-0 left-0 z-30 flex h-screen w-screen">

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -2,12 +2,12 @@
   <div class="flex items-center rounded-lg bg-gray-200 px-4 py-2">
     <router-link :to="localizedUrl(link)" v-if="link">
       <div class="inline-flex items-center justify-center">
-        <span class="material-icons text-warmgray-600 mr-2 text-lg">{{ icon }}</span>
+        <span class="material-symbols-outlined text-warmgray-600 mr-2 text-lg">{{ icon }}</span>
         <span class="text-warmgray-600 text-sm font-bold">{{ $t(title) }}</span>
       </div>
     </router-link>
     <div class="inline-flex items-center justify-center" v-else>
-      <span class="material-icons text-warmgray-600 mr-2 text-lg">{{ icon }}</span>
+      <span class="material-symbols-outlined text-warmgray-600 mr-2 text-lg">{{ icon }}</span>
       <span class="text-warmgray-600 text-sm font-bold">{{ $t(title) }}</span>
     </div>
   </div>


### PR DESCRIPTION
Material Icons を Material Symbols に変更しました。

Material Icons では、
- Material Icons
- Material Icons Outlined

の2つの icon を1つの <link> タグにてインポートしているようですが、Material Symbols ではそのようなインポートの仕方が出来ませんでした (*) ので、2つの <link> タグにて

- Material Symbols Outlined
- Material Symbols Sharp

をインポートしています。

> (*)
> インポート URL である
> https://fonts.googleapis.com/icon と
> https://fonts.googleapis.com/css2 の違いのせいかも知れません。

2つの icon をインポートしていますが、class 名を 

- material-symbols-outlined
- material-symbols-sharp

のどちから一方のみを指定する必要があるため、使用していない Material Symbols Sharp は不要かも知れません。

以上です。レビュー、よろしくお願いいたします。