### PR TITLE
docs: add project CLAUDE.md and Claude Code skills

### DIFF
--- a/.claude/skills/add-function/SKILL.md
+++ b/.claude/skills/add-function/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: add-function
+description: Scaffold a new Firebase Cloud Function in this repo's exportIfNeeded cold-start pattern. Use when asked to "add a function", "functionを追加", "Cloud Functionをつくって", "callableを追加して", "APIエンドポイントを追加". Creates the functions/src/functions logic + wrappers config, registers it in index.ts, and (for callables) adds the client-side httpsCallable in src/utils/functions.ts.
+---
+
+# Add a Cloud Function
+
+Functions are split in two so cold starts stay small and logic stays testable:
+- **`functions/src/functions/<name>.ts`** — the business logic.
+- **`functions/src/wrappers/<name>.ts`** — the `firebase-functions` binding (region, memory,
+  timeout, App Check). Only the invoked wrapper is `require`d at runtime.
+
+## Steps
+
+### 1. Logic — `functions/src/functions/<name>.ts`
+Keep it a plain async function that takes what it needs and returns data. Example:
+```ts
+import { CallableRequest } from "firebase-functions/v2/https";
+
+export const greet = async (request: CallableRequest<{ name: string }>) => {
+  const name = request.data.name ?? "world";
+  return { message: `Hello, ${name}!` };
+};
+```
+
+### 2. Wrapper — `functions/src/wrappers/<name>.ts`
+Bind region / limits / App Check. Callable (v2) pattern:
+```ts
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { greet } from "../functions/greet";
+
+const REGION = "asia-northeast1";
+
+export default onCall({ region: REGION, memory: "1GiB", maxInstances: 5 }, async (request) => {
+  if (request.app == undefined) {
+    throw new HttpsError("failed-precondition", "Call must come from an App Check verified app.");
+  }
+  return await greet(request);
+});
+```
+For an HTTP endpoint follow the v1 hono/express wrappers instead
+(`wrappers/server/hono.ts` → `.region(...).runWith({...}).https.onRequest(...)`), and add a
+hosting rewrite in `firebase.json`.
+
+### 3. Register — `functions/src/index.ts`
+```ts
+exportIfNeeded("greet", "greet", exports);
+// exportIfNeeded(publicFunctionName, wrapperFilePathUnderWrappers, exports)
+```
+The 1st arg is the deployed function name; the 2nd is the wrapper path relative to
+`functions/src/wrappers/` (no extension).
+
+### 4. Client hook (callables only) — `src/utils/functions.ts`
+```ts
+export const greetFunction = httpsCallable(functions, "greet");
+```
+Call it from a component: `const { data } = await greetFunction({ name });`. The client
+`functions` instance is pinned to `asia-northeast1` (`src/utils/firebase.ts`) — the region must
+match the wrapper.
+
+### 5. Verify
+```bash
+yarn --cwd functions lint
+yarn --cwd functions build
+yarn --cwd functions serve   # emulator; exercise the function
+```
+
+## Conventions
+- No `any`; type `request.data` and the return value. Double quotes, semicolons, 2-space indent.
+- Set `maxInstances` / `timeoutSeconds` / `memory` deliberately (cost + abuse ceiling).
+- Guard callables with the `request.app` App Check check and, for user data, `request.auth`.
+- Deploy with `firebase deploy --only functions` (predeploy runs lint + build automatically).

--- a/.claude/skills/add-page/SKILL.md
+++ b/.claude/skills/add-page/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: add-page
+description: Scaffold a new Vue page/view in this repo with i18n URL-path routing. Use when asked to "add a page", "ページを追加", "画面をつくって", "viewを追加して", "新しいルートを追加". Creates the view, registers it in routeChildren (so it works at both / and /:lang), and adds en/ja i18n keys — following Composition API, @/ alias, no-<script setup>, and Tailwind conventions.
+---
+
+# Add a Vue page
+
+Every page renders at both `/<path>` and `/:lang/<path>` (e.g. `/about` and `/ja/about`) because
+`src/router/index.ts` mounts one `routeChildren` list under both the `/:lang` tree and the root
+tree. Add the page once to that list.
+
+## Steps
+
+### 1. View — `src/views/<Name>.vue`
+Use Composition API via `defineComponent` / `setup()` (NOT `<script setup>` for real pages).
+All display text goes through `$t()`; links go through `localizedUrl`.
+```vue
+<template>
+  <div class="p-4">
+    <h1 class="text-xl font-bold">{{ $t("profile.title") }}</h1>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { useHead } from "@unhead/vue";
+
+export default defineComponent({
+  name: "ProfilePage",
+  setup() {
+    useHead({ title: "Profile" });
+    return {};
+  },
+});
+</script>
+```
+
+### 2. Route — `src/router/index.ts`
+Import the view and add ONE entry to `routeChildren` (both trees inherit it). Use a relative
+child `path` (no leading slash):
+```ts
+import Profile from "@/views/Profile.vue";
+// …
+{ path: "profile", component: Profile },
+```
+
+### 3. i18n keys — `src/i18n/en.ts` AND `src/i18n/ja.ts`
+Add the same key to **both** files (keep them in sync):
+```ts
+// en.ts
+profile: { title: "Profile" },
+// ja.ts
+profile: { title: "プロフィール" },
+```
+
+### 4. Links to the page
+Never hardcode `/ja/...`. Use `localizedUrl` from `useLang()` (`src/utils/utils.ts`) so the
+current language is preserved:
+```ts
+const { localizedUrl } = useLang();
+router.push(localizedUrl("/profile"));
+```
+Or `useLocalizedRoute()` for a ready-made push helper.
+
+### 5. Auth guard (optional)
+- Members-only page: `requireLogin("/account")` — redirects signed-out users.
+- Login/landing page that should skip signed-in users: `noLoginPage("/mypage")`.
+  Both live in `src/utils/utils.ts` and clean up their watchers on unmount.
+
+### 6. Verify
+```bash
+yarn lint
+yarn build
+yarn serve   # check /profile AND /ja/profile
+```
+
+## Conventions
+- `@/` alias imports (repo standard — do NOT use relative paths here).
+- `emit` for child→parent, never function props. `ref` over `reactive`. No `v-html`.
+- Tailwind utility classes; avoid `<style>` blocks. Double quotes, semicolons, 2-space indent.

--- a/.claude/skills/firebase-security-review/SKILL.md
+++ b/.claude/skills/firebase-security-review/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: firebase-security-review
+description: Audit this Firebase + Vue app for security issues before deploy. Use when asked to "security review", "セキュリティレビュー", "安全性チェック", "デプロイ前チェック", "脆弱性チェック", or after changing rules / functions / auth. Covers Firestore & Storage rules, App Check enforcement, exposed secrets, callable-function auth guards, and hosting / CSP headers. Reports findings with severity, file:line, and a concrete fix.
+---
+
+# Firebase security review
+
+Audit the surfaces below. For each finding report **severity (High / Med / Low)**, `file:line`,
+why it matters, and the concrete fix. Verify claims against the code — do not assume.
+
+## 1. Firestore & Storage rules (`firestore.rules`, `storage.rules`)
+- Default-deny catch-all present and last? Any `if true` / unauthenticated writes to real data?
+- Per-user data gated on `request.auth.uid`? Write payloads validated (`hasOnly`, type/size)?
+- Storage scoped per path, or a blanket `if request.auth != null` over `{allPaths=**}`?
+  (deep-dive with the **firestore-rules** skill).
+
+## 2. App Check
+- `functions/src/wrappers/firebase.ts` → `enforceAppCheck`. If `false`, callables are reachable
+  by anything with the public config.
+- v2 callables should reject un-attested calls:
+  ```ts
+  if (context.app == undefined) {
+    throw new HttpsError("failed-precondition", "…App Check verified app.");
+  }
+  ```
+  Confirm each `onCall` in `functions/src/wrappers/` has this guard (see `wrappers/func.ts`).
+
+## 3. Secrets vs. public config
+- `src/config/project.ts` firebaseConfig is **public web config — not a leak.** Don't flag it.
+- DO flag: service-account JSON, private keys, API secrets, or tokens committed anywhere, or
+  secrets hardcoded in `functions/` instead of `functions.config()` / Secret Manager
+  (`secretKeys` in `wrappers/firebase.ts`). Grep for `PRIVATE KEY`, `secret`, `token`, `.json`
+  credential files.
+
+## 4. Function authorization & input
+- Every `onCall` that touches user data must check `context.auth` before acting — a signed-out
+  or wrong user must not read/write another's data.
+- HTTP servers (`functions/functions/server/*` hono/express) exposed via hosting rewrites
+  (`/api/*`, `/hono_api/*`, `/v2_api/*`): validate/authorize each route; don't trust the body.
+- Set sane `runWith` limits (`maxInstances`, `timeoutSeconds`, `memory`) to cap abuse/cost.
+
+## 5. Hosting headers (`firebase.json`)
+- Confirm CSP `frame-ancestors 'none'`, `X-Frame-Options: deny`, `X-Content-Type-Options:
+  nosniff`, `Referrer-Policy: no-referrer` are still present on `source: "**"`.
+
+## 6. Frontend
+- No `v-html` (XSS); no secrets in client code; auth guards (`requireLogin`) actually block
+  protected views rather than only hiding UI.
+
+## 7. Dependencies
+- `yarn npm audit` (root and `functions/`) for known-vulnerable packages; note Dependabot alerts.
+
+## Output
+Group findings by severity, most severe first. If clean, say so explicitly and list what was
+checked. Recommend the exact deploy scope for any fix
+(`firebase deploy --only firestore:rules` etc.).

--- a/.claude/skills/firestore-rules/SKILL.md
+++ b/.claude/skills/firestore-rules/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: firestore-rules
+description: Write or review Firebase Firestore (firestore.rules) and Storage (storage.rules) security rules for this repo. Use when adding a collection, changing access control, or auditing rules — triggers like "firestore rules", "セキュリティルール", "rulesを書いて", "このコレクションのread/writeを許可して", "storage.rules", "権限設定". Enforces default-deny, request.auth checks, field validation, and emulator testing.
+---
+
+# Firestore / Storage security rules
+
+Security rules are the ONLY thing standing between the public internet and the database —
+the Firebase web API key is public, so rules (plus App Check) are the real access control.
+
+## Files
+- `firestore.rules` — Firestore access, referenced by `firebase.json` (`firestore.rules`).
+- `storage.rules` — Cloud Storage access.
+- `firestore.indexes.json` — composite indexes (add here when a query needs one).
+
+## Non-negotiables
+
+1. **Default-deny stays last.** Keep the catch-all at the bottom and never loosen it:
+   ```
+   match /{document=**} {
+     allow read, write: if false;
+   }
+   ```
+   Grant access per collection ABOVE it; the most specific match wins.
+
+2. **Split the verbs.** `read` = `get` + `list`; `write` = `create` + `update` + `delete`.
+   Grant only what the feature needs. Current repo pattern:
+   ```
+   match /message/{messageId} {
+     allow read, create;              // public read + append
+     allow delete, update: if false;  // immutable, no removal
+   }
+   ```
+
+3. **Gate on auth, then on ownership.** For user-owned data check both the caller and the doc:
+   ```
+   match /users/{uid} {
+     allow read: if request.auth != null && request.auth.uid == uid;
+     allow write: if request.auth != null
+                  && request.auth.uid == uid
+                  && request.resource.data.keys().hasOnly(["name", "email", "updatedAt"]);
+   }
+   ```
+
+4. **Validate the payload on writes.** Use `request.resource.data` to constrain shape / types /
+   size; use `resource.data` for the pre-write state. Reject unexpected fields with `hasOnly`.
+
+5. **Never call functions / external services from rules.** Rules must be pure and fast.
+
+## Storage rules
+`storage.rules` currently grants any signed-in user full access:
+```
+match /{allPaths=**} {
+  allow read, write: if request.auth != null;
+}
+```
+Tighten per path when you add uploads — scope by `uid`, validate `request.resource.size` and
+`request.resource.contentType` (e.g. images under a size cap).
+
+## Test before shipping
+```bash
+firebase emulators:start --only firestore,storage   # exercise reads/writes manually
+# or write rules unit tests with @firebase/rules-unit-testing and run against the emulator
+```
+Cover: allowed happy path, unauthenticated denial, wrong-owner denial, malformed-payload denial,
+and the default-deny catch-all for an unlisted collection.
+
+## Review checklist
+- [ ] Default-deny catch-all present and unmodified.
+- [ ] No `allow read, write: if true` or unauthenticated writes to real data.
+- [ ] Ownership enforced (`request.auth.uid == …`) for per-user data.
+- [ ] Write payloads validated (`hasOnly`, type/size checks).
+- [ ] New indexed queries have entries in `firestore.indexes.json`.
+- [ ] Storage paths scoped + size/content-type limited (not blanket auth).
+- [ ] Emulator-tested: allow AND deny cases.
+
+After changes: `firebase deploy --only firestore:rules,storage`. For a broader pass run the
+**firebase-security-review** skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,167 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository. It complements the global
+`~/.claude/CLAUDE.md`; where the two differ, the notes here win **inside this repo**
+(most importantly: this repo uses `@/` alias imports, not relative paths).
+
+## What this is
+
+A production-ready starter kit for **Firebase + Vue 3** web apps. Cloning it gives you a
+working app — social auth, i18n URL-path routing, a Pinia store, and Cloud Functions — to
+build on top of. Two independent npm packages live here:
+
+- **Root (`/`)** — the Vue 3 SPA (Vite), deployed to Firebase Hosting.
+- **`functions/`** — Cloud Functions (TypeScript), deployed to `asia-northeast1` (Tokyo).
+
+Each has its own `package.json`, `yarn.lock`, `tsconfig.json`, and eslint config.
+**Install, lint, and build them separately.**
+
+## After cloning
+
+```bash
+# 1. Install both packages (yarn — never npm)
+yarn install
+yarn --cwd functions install
+
+# 2. Install the Firebase CLI once
+yarn global add firebase-tools     # or: npm i -g firebase-tools
+
+# 3. Point the kit at YOUR Firebase project
+#    - Firebase console -> create project -> add a Web app (</>)
+#    - paste the SDK config into src/config/project.ts (firebaseConfig)
+#    - replace "fir-vue-startup-kit" in .firebaserc with your project id
+#    - enable Firestore, Authentication (Google / Facebook), and Hosting
+
+# 4. Run locally
+yarn serve                    # Vite dev server -> http://localhost:8080
+yarn --cwd functions serve    # Functions emulator
+```
+
+`src/config/project.ts` is committed with the demo project's config. Those Firebase **web**
+API keys are *not* secrets — web keys are public by design; access is enforced by Firestore /
+Storage rules and App Check, not by hiding the key. Replace them with your own project's values.
+
+## Commands
+
+Root (Vue app):
+
+| Command | What it does |
+|---|---|
+| `yarn serve` | Vite dev server (port 8080) |
+| `yarn build` | `vue-tsc` typecheck + `vite build` -> `dist/` |
+| `yarn lint` | ESLint over `src` |
+| `yarn format` | Prettier write |
+
+Functions (`yarn --cwd functions <script>`):
+
+| Command | What it does |
+|---|---|
+| `yarn build` | `tsc` -> `lib/` |
+| `yarn lint` / `yarn format` | ESLint / Prettier |
+| `yarn serve` | build + functions emulator |
+| `yarn deploy` | `firebase deploy --only functions` |
+| `yarn logs` | tail function logs |
+
+CI (`.github/workflows/pull_request.yaml`) runs lint + build for **both** packages on Node 24.
+Run `yarn lint && yarn build` in each before pushing.
+
+## Project structure
+
+```
+src/
+  config/project.ts      firebaseConfig (replace with your project)
+  utils/firebase.ts      initializeApp + db / auth / functions (asia-northeast1)
+  utils/functions.ts     httpsCallable wrappers for client -> function calls
+  utils/SocialLogin.ts   Google / Facebook signInWithPopup
+  utils/utils.ts         useUser / useIsSignedIn / requireLogin / noLoginPage / useLang
+  store/index.ts         Pinia store — holds the auth User
+  router/index.ts        routes; every page is nested under /:lang AND root
+  i18n/                  en.ts / ja.ts messages, languages.ts, utils.ts (useI18nParam)
+  components/Layout.vue  wires onAuthStateChanged -> store, and useI18nParam
+  views/                 pages (Home, About, Account, MyPage)
+functions/src/
+  index.ts               registers functions via exportIfNeeded(...)
+  common/exportifneeded.ts   cold-start loader
+  functions/             business logic (hono / express servers, callables)
+  wrappers/              firebase-functions config (region / memory / timeout) per function
+firestore.rules / storage.rules    security rules
+firebase.json            hosting (headers, rewrites), functions, firestore, storage
+```
+
+## Key patterns (read before editing)
+
+### Cloud Functions — cold-start optimization
+`functions/src/index.ts` registers each function with `exportIfNeeded(name, file, exports)`.
+At runtime only the invoked function's module is `require`d, keeping cold starts small. Each
+function is split in two:
+- `functions/src/functions/<x>.ts` — the logic (kept testable).
+- `functions/src/wrappers/<x>.ts` — the `firebase-functions` binding (region, memory, timeout,
+  App Check).
+
+Adding one: write logic + wrapper, register in `index.ts`, and for callables add an
+`httpsCallable` in `src/utils/functions.ts`. → skill **add-function**.
+
+### i18n URL-path routing
+Pages render at both `/` and `/:lang/` (e.g. `/about`, `/ja/about`). New pages go in
+`routeChildren` in `src/router/index.ts` so both trees pick them up. `Layout.vue` calls
+`useI18nParam()` to sync `route.params.lang` -> i18n locale. Build links with `localizedUrl()`
+(from `useLang()`); never hardcode `/ja/...`. All display text uses `$t()` / `$n()` — add keys
+to **both** `src/i18n/en.ts` and `src/i18n/ja.ts`. → skill **add-page**.
+
+### Auth state
+`Layout.vue` subscribes to `auth.onAuthStateChanged` and pushes the user into the Pinia store.
+Read it via `useUser()` / `useIsSignedIn()`. Guard pages with `requireLogin(path)` /
+`noLoginPage(path)` from `src/utils/utils.ts`.
+
+## Conventions
+
+The authoritative style guide is **`docs/StyleGuide.md`** (Japanese). Highlights, enforced by a
+strict eslint config (`eslint.configs.all` + typescript-eslint strict + vue strongly-recommended
++ sonarjs):
+
+- **Vue**: Composition API. Avoid `<script setup>` for non-trivial components (this repo prefers
+  explicit `defineComponent` / `setup()` so template-facing vs internal state stays visible);
+  reserve `<script setup>` for tiny components. Use `emit`, not function props. Prefer `ref` over
+  `reactive`. Never `v-html`.
+- **Imports**: use the **`@/` alias** (configured in `vite.config.js` + `tsconfig.json`).
+  ⚠️ This overrides the global "relative paths only" rule *inside this repo* — the whole codebase
+  and the StyleGuide use `@/`.
+- **TypeScript**: explicit types; no `any` / `unknown`; avoid `as`. Double quotes, semicolons,
+  2-space indent (all eslint-enforced).
+- **i18n**: never hardcode strings in templates — `$t()` / `$n()`, `localizedUrl` for links.
+- **Firestore**: modular v9+ API; wrap document data in model classes (`src/models/`, per the
+  StyleGuide) so types + mutations live in one place; always detach `onSnapshot` listeners.
+- **Style**: Tailwind utility classes; avoid `<style>` blocks unless unavoidable.
+- **Git**: small frequent commits, no rebase, no force-push; run `yarn format` before committing.
+
+## Deploy
+
+```bash
+yarn build              # produce dist/ (hosting serves this)
+firebase deploy         # hosting + functions + rules
+# or scope it:
+firebase deploy --only hosting
+firebase deploy --only functions
+firebase deploy --only firestore:rules,storage
+```
+
+The functions predeploy hook (`firebase.json`) auto-runs lint + build. Functions and their
+client callers (`src/utils/firebase.ts`) both pin **`asia-northeast1`** — change both together if
+you move regions. Hosting rewrites `/hono_api/*`, `/api/*`, `/v2_api/*` to server functions.
+
+## Security
+
+- **Rules default-deny**: `firestore.rules` ends with `allow read, write: if false`; open only
+  what each collection needs. `storage.rules` requires `request.auth != null`.
+- **App Check**: v2 callables check `context.app` (see `wrappers/func.ts`); `wrappers/firebase.ts`
+  carries an `enforceAppCheck` flag.
+- **Hosting headers**: CSP `frame-ancestors 'none'`, `X-Frame-Options: deny`, `nosniff`,
+  `no-referrer` (`firebase.json`).
+- Run skill **firebase-security-review** before deploying rule or function changes.
+
+## Skills (`.claude/skills/`)
+
+- **firestore-rules** — write / review Firestore & Storage security rules.
+- **firebase-security-review** — audit rules, App Check, secrets, auth guards, headers.
+- **add-function** — scaffold a Cloud Function in the `exportIfNeeded` pattern.
+- **add-page** — scaffold a Vue page + route + i18n keys.


### PR DESCRIPTION
## Summary
Adds repo-level guidance for Claude Code (a project `CLAUDE.md`) plus four `.claude/skills/` skills, all grounded in this kit's actual patterns (verified against the source, not assumed). Documentation/tooling only — no application code changes, so build/CI behavior is unaffected.

## Items to Confirm / Review
- **`@/` alias vs. relative imports**: `CLAUDE.md` states this repo uses `@/` alias imports (per `docs/StyleGuide.md` and the whole codebase). This intentionally overrides the "relative paths only" preference in the global `~/.claude/CLAUDE.md` *within this repo*. Confirm you're happy documenting `@/` as the in-repo standard.
- **Node version**: `CLAUDE.md` says Node 24 (matches CI matrix + `functions` engine). Same value as PR #63 for README.
- **Skill scope**: I generated all four proposed skills since they map to the categories you named (firestore rules / security review / vue / firebase). Prune any you don't want.
- **Firebase web config**: both `CLAUDE.md` and the security-review skill explicitly note `src/config/project.ts` keys are public-by-design (not a leak), to avoid false positives. Confirm that's the intended stance.

## User Prompt
> つづいて、これらの知識を元に claude.md をつくろう。clone したあとに、なにをすべきかのインストラクションや、このレポを使って役立つこととか。必要なら skills をいっぱいつくってもよいよ。firestore rules とか、セキュリティレビューとか vue とか firebase むけの。

## What's included
**`CLAUDE.md`** — post-clone setup (two npm packages: root + `functions/`), commands, structure map, deploy, security, and the non-obvious patterns:
- Functions cold-start optimization (`exportIfNeeded` + logic/`wrappers/` split)
- i18n URL-path routing (`/` and `/:lang`, `localizedUrl`)
- `Layout.vue` `onAuthStateChanged` → Pinia auth flow
- Conventions summarized from `docs/StyleGuide.md` + the strict eslint config

**`.claude/skills/`**
| Skill | Purpose |
|---|---|
| `firestore-rules` | Write/review `firestore.rules` & `storage.rules` (default-deny, auth/ownership, validation, emulator tests) |
| `firebase-security-review` | Pre-deploy audit: rules, App Check, secrets, callable auth guards, CSP headers |
| `add-function` | Scaffold a Cloud Function in the `exportIfNeeded` pattern (logic + wrapper + `index.ts` + client hook) |
| `add-page` | Scaffold a Vue view + `routeChildren` registration + en/ja i18n keys |

Each skill description includes Japanese trigger phrases so it fires in Japanese conversations too.

## Note
Independent of PR #63 (README refresh). No file overlap; both target `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)