### PR TITLE
docs: make Functions security guidance v2-accurate

### DIFF
--- a/.claude/skills/firebase-security-review/SKILL.md
+++ b/.claude/skills/firebase-security-review/SKILL.md
@@ -15,29 +15,29 @@ why it matters, and the concrete fix. Verify claims against the code — do not 
   (deep-dive with the **firestore-rules** skill).
 
 ## 2. App Check
-- `functions/src/wrappers/firebase.ts` → `enforceAppCheck`. If `false`, callables are reachable
-  by anything with the public config.
-- v2 callables should reject un-attested calls:
+- Callables should enforce App Check — either the `enforceAppCheck: true` option, or a manual
+  guard that rejects un-attested calls:
   ```ts
-  if (context.app == undefined) {
+  if (request.app == undefined) {
     throw new HttpsError("failed-precondition", "…App Check verified app.");
   }
   ```
-  Confirm each `onCall` in `functions/src/wrappers/` has this guard (see `wrappers/func.ts`).
+  Confirm each `onCall` in `functions/src/wrappers/` enforces this. Without it, callables are
+  reachable by anything holding the public config.
 
 ## 3. Secrets vs. public config
 - `src/config/project.ts` firebaseConfig is **public web config — not a leak.** Don't flag it.
 - DO flag: service-account JSON, private keys, API secrets, or tokens committed anywhere, or
-  secrets hardcoded in `functions/` instead of `functions.config()` / Secret Manager
-  (`secretKeys` in `wrappers/firebase.ts`). Grep for `PRIVATE KEY`, `secret`, `token`, `.json`
-  credential files.
+  secrets hardcoded in `functions/` instead of Cloud Secret Manager (`defineSecret` from
+  `firebase-functions/params`). Grep for `PRIVATE KEY`, `secret`, `token`, `.json` credential
+  files.
 
 ## 4. Function authorization & input
-- Every `onCall` that touches user data must check `context.auth` before acting — a signed-out
+- Every `onCall` that touches user data must check `request.auth` before acting — a signed-out
   or wrong user must not read/write another's data.
 - HTTP servers (`functions/functions/server/*` hono/express) exposed via hosting rewrites
   (`/api/*`, `/hono_api/*`, `/v2_api/*`): validate/authorize each route; don't trust the body.
-- Set sane `runWith` limits (`maxInstances`, `timeoutSeconds`, `memory`) to cap abuse/cost.
+- Set sane resource limits in the function options (`maxInstances`, `timeoutSeconds`, `memory`) to cap abuse/cost.
 
 ## 5. Hosting headers (`firebase.json`)
 - Confirm CSP `frame-ancestors 'none'`, `X-Frame-Options: deny`, `X-Content-Type-Options:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,8 @@ you move regions. Hosting rewrites `/hono_api/*`, `/api/*`, `/v2_api/*` to serve
 
 - **Rules default-deny**: `firestore.rules` ends with `allow read, write: if false`; open only
   what each collection needs. `storage.rules` requires `request.auth != null`.
-- **App Check**: v2 callables check `context.app` (see `wrappers/func.ts`); `wrappers/firebase.ts`
-  carries an `enforceAppCheck` flag.
+- **App Check**: enforce it on callables — either the `enforceAppCheck: true` option, or a manual
+  guard (`if (request.app == undefined) throw new HttpsError(...)`).
 - **Hosting headers**: CSP `frame-ancestors 'none'`, `X-Frame-Options: deny`, `nosniff`,
   `no-referrer` (`firebase.json`).
 - Run skill **firebase-security-review** before deploying rule or function changes.


### PR DESCRIPTION
## Summary
Follow-up from the retrospective review of the v2 unification (#65). Docs-only. The v2 migration made the codebase 2nd-gen-only, but `CLAUDE.md` and the `firebase-security-review` skill still used 1st gen idiom and pointed at **untracked scratch files** (`wrappers/func.ts`, `wrappers/firebase.ts`) that a fresh clone doesn't have.

## Items to Confirm / Review
- **v1 → v2 API terms**: `context.auth` → `request.auth`, `context.app` → `request.app`, `runWith` limits → options object, `functions.config()` → Secret Manager (`defineSecret` from `firebase-functions/params`). Confirm these match how you want App Check / secrets described.
- **Dropped scratch-file references**: the App Check and secrets guidance no longer names `wrappers/func.ts` / `wrappers/firebase.ts` (both untracked WIP) — it describes the patterns generically instead. If you intend to commit those files as canonical examples, tell me and I'll point the docs back at them instead.

## Why (review context)
`/codex-cross-review` was run on #65, but:
1. **#65 was already merged** — the convergence loop can't gate a merged PR, so I did a retrospective review instead.
2. **The `codex` CLI is broken** on this machine — the wrapper resolves but its native binary fails to spawn (`ENOENT` on `@openai/codex-darwin-arm64/.../codex`). No Codex verdict was produced. Reinstall with `npm i -g @openai/codex` to restore cross-reviews.

The v2 migration in #65 itself reviewed clean (correct v1→v2 `onRequest`, `1GiB` memory, hono adapter types, express consolidation with all routes preserved, no v1 remnants, CI green). These doc fixes are the only real findings, surfaced during my own review — not from Codex.

## Changes
| File | Change |
|---|---|
| `CLAUDE.md` | App Check bullet → v2 idiom, no scratch-file refs |
| `.claude/skills/firebase-security-review/SKILL.md` | App Check / auth / limits / secrets guidance → v2, no scratch-file refs |

Docs-only — no code touched; nothing to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)