### PR TITLE
chore: tighten eslint for compact, DRY code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import eslint from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import sonarjs from "eslint-plugin-sonarjs";
-import pluginVue from 'eslint-plugin-vue';
+import pluginVue from "eslint-plugin-vue";
 import vueParser from "vue-eslint-parser";
 import eslintConfigPrettier from "eslint-config-prettier";
 
@@ -11,23 +11,24 @@ export default [
     files: ["src/**/*.{vue,ts}"],
   },
   {
-    ignores: ["**/*js", "functions"]
+    ignores: ["**/*js", "functions"],
   },
   eslint.configs.all,
-  ...tseslint.configs.strict,
-  ...pluginVue.configs['flat/strongly-recommended'],
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  ...pluginVue.configs["flat/strongly-recommended"],
   sonarjs.configs.recommended,
   {
     plugins: {
-      'typescript-eslint': tseslint.plugin,
+      "typescript-eslint": tseslint.plugin,
     },
     languageOptions: {
       globals: globals.browser,
       parserOptions: {
         parser: tseslint.parser,
-        project: './tsconfig.json',
-        extraFileExtensions: ['.vue'],
-        sourceType: 'module',
+        project: "./tsconfig.json",
+        extraFileExtensions: [".vue"],
+        sourceType: "module",
       },
     },
   },
@@ -39,6 +40,7 @@ export default [
         {
           argsIgnorePattern: "^__",
           varsIgnorePattern: "^__",
+          caughtErrorsIgnorePattern: "^__",
         },
       ],
       "@typescript-eslint/no-explicit-any": "error",
@@ -48,15 +50,31 @@ export default [
 
       "capitalized-comments": "off",
       "no-unreachable": "error",
+      "no-void": ["error", { allowAsStatement: true }],
       "one-var": "off",
       "no-undefined": "off",
       "sort-keys": "off",
       "sort-vars": "off",
       "sort-imports": "off",
       "no-magic-numbers": "off",
+
+      // Compact & DRY: hard ceilings on size, nesting, complexity, and arity
+      "max-lines": ["error", { max: 200, skipBlankLines: true, skipComments: true }],
+      "max-lines-per-function": ["error", { max: 20, skipBlankLines: true, skipComments: true }],
+      "max-statements": ["error", 10],
+      complexity: ["error", 10],
+      "max-depth": ["error", 3],
+      "max-nested-callbacks": ["error", 3],
+      "max-params": ["error", 3],
+
       "vue/no-unused-vars": "error",
+      "vue/no-unused-refs": "error",
       "vue/no-reserved-component-names": "error",
       "vue/multi-word-component-names": "off",
+      "vue/require-explicit-emits": "error",
+      "vue/no-mutating-props": "error",
+      "vue/no-useless-v-bind": "error",
+      "vue/no-v-html": "error",
       "sonarjs/cognitive-complexity": "error",
       "sonarjs/elseif-without-else": "error",
       "sonarjs/max-switch-cases": "error",
@@ -90,7 +108,6 @@ export default [
       "sonarjs/prefer-while": "error",
       "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
       "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
-
     },
   },
   eslintConfigPrettier,

--- a/src/components/Languages.vue
+++ b/src/components/Languages.vue
@@ -15,6 +15,14 @@ import { useI18n } from "vue-i18n";
 
 import { languages } from "@/i18n/index";
 
+const buildLangPath = (route: ReturnType<typeof useRoute>, langValue: string) => {
+  const { lang } = route.params;
+  if (typeof lang === "string") {
+    return `/${langValue}${route.path.slice(lang.length + 1)}`;
+  }
+  return `/${langValue}${route.path}`;
+};
+
 export default defineComponent({
   setup() {
     const route = useRoute();
@@ -22,16 +30,10 @@ export default defineComponent({
     const i18n = useI18n();
     const selectedValue = ref(i18n.locale.value);
     const updateValue = (event: Event) => {
-      const basePath = (() => {
-          if (route.params.lang) {
-            return route.path.slice(route.params.lang.length + 1);
-          }
-          return route.path;
-        })(),
-        target = event.target as HTMLSelectElement,
-        newPath = `/${target.value}${basePath}`;
+      const target = event.target as HTMLSelectElement;
+      const newPath = buildLangPath(route, target.value);
       if (newPath !== route.path) {
-        router.push(newPath);
+        void router.push(newPath);
       }
     };
     return {

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -40,6 +40,13 @@ interface UserData {
   user: User | null;
 }
 
+const watchAuthState = (store: ReturnType<typeof useStore>, user: UserData) => {
+  auth.onAuthStateChanged((fbuser) => {
+    user.user = fbuser;
+    store.setUser(fbuser);
+  });
+};
+
 export default defineComponent({
   name: "AppLayout",
   components: {
@@ -52,17 +59,8 @@ export default defineComponent({
     const menu = ref(false);
 
     useI18nParam();
-
     onMounted(() => {
-      auth.onAuthStateChanged((fbuser) => {
-        if (fbuser) {
-          console.log("authStateChanged:");
-          user.user = fbuser;
-          store.setUser(fbuser);
-        } else {
-          store.setUser(null);
-        }
-      });
+      watchAuthState(store, user);
     });
 
     const toggleMenu = () => {

--- a/src/components/MenuList.vue
+++ b/src/components/MenuList.vue
@@ -30,7 +30,7 @@ export default defineComponent({
       ctx.emit(emitClose);
     };
     const logout = () => {
-      signOut(auth);
+      void signOut(auth);
       ctx.emit(emitClose);
     };
     return {

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -5,7 +5,7 @@ import { useRoute } from "vue-router";
 export const i18nUtils = (app: App) => {
   app.config.globalProperties.localizedUrl = (path: string) => {
     const { lang } = app.config.globalProperties.$route.params;
-    if (lang) {
+    if (typeof lang === "string") {
       return `/${lang}${path}`;
     }
     return path;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,7 +8,7 @@ import Account from "@/views/Account.vue";
 import About from "@/views/About.vue";
 import MyPage from "@/views/MyPage.vue";
 
-const routeChildren: Array<RouteRecordRaw> = [
+const routeChildren: RouteRecordRaw[] = [
   {
     path: "",
     component: Home,
@@ -26,7 +26,7 @@ const routeChildren: Array<RouteRecordRaw> = [
     component: MyPage,
   },
 ];
-const routes: Array<RouteRecordRaw> = [
+const routes: RouteRecordRaw[] = [
   {
     path: "/",
     component: Layout,

--- a/src/utils/SocialLogin.ts
+++ b/src/utils/SocialLogin.ts
@@ -19,11 +19,11 @@ const authSignIn = async (provider: AuthProvider, callback?: () => void, errorCa
 export const googleSignin = (callback?: () => void, errorCallback?: ErrorFunc) => () => {
   const provider = new GoogleAuthProvider();
   provider.addScope("email");
-  authSignIn(provider, callback, errorCallback);
+  void authSignIn(provider, callback, errorCallback);
 };
 
 export const facebookSignin = (callback?: () => void, errorCallback?: ErrorFunc) => () => {
   const provider = new FacebookAuthProvider();
   provider.addScope("email,user_birthday");
-  authSignIn(provider, callback, errorCallback);
+  void authSignIn(provider, callback, errorCallback);
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -39,7 +39,7 @@ export const useLocalizedRoute = () => {
   const { localizedUrl } = useLang();
 
   return (path: string) => {
-    router.push(localizedUrl(path));
+    void router.push(localizedUrl(path));
   };
 };
 

--- a/src/views/MyPage.vue
+++ b/src/views/MyPage.vue
@@ -10,15 +10,15 @@ export default defineComponent({
   setup() {
     requireLogin("/account");
 
-    (async () => {
+    void (async () => {
       const { stream, data } = await streamingFcuntion.stream();
       for await (const chunk of stream) {
         console.log(chunk);
       }
       const allData = await data;
       console.log(allData);
-    })()
-    
+    })();
+
     return {};
   },
 });


### PR DESCRIPTION
## Summary
Makes the **root (Vue app) `eslint.config.mjs`** much stricter to enforce compact, DRY code, modelled on the sibling `graphai-demo-web` / `mulmocast-app` flat configs. Includes the small code fixes needed for the existing `src` to pass the new rules. Root config only (`src`); `functions/` untouched.

## Items to Confirm / Review
- **`max-lines-per-function: 20`** (matches the global "functions under 20 lines" rule). This flagged two `setup()` functions, which I fixed by extracting module-level helpers (`buildLangPath`, `watchAuthState`). Confirm 20 is the ceiling you want, or say and I'll relax it.
- **`Layout.vue` behavior change** (only non-mechanical fix): extracting the auth listener simplified it to `user.user = fbuser; store.setUser(fbuser);` — dropping the `if/else` and a debug `console.log`. On logout it now also resets `user.user` to `null` (was left stale). `user` is not used in the template, so this is safe, but flagging it.
- **`strictTypeChecked` scope**: type-aware rules apply to `src` only (lint command is `eslint src`, tsconfig covers it). Confirm you're OK with the type-aware ruleset (it needs `project` set, which it already is).

## Config changes
**TypeScript** — the big lever (tighter than any sibling, which stop at `strict`):
```diff
- ...tseslint.configs.strict,
+ ...tseslint.configs.strictTypeChecked,
+ ...tseslint.configs.stylisticTypeChecked,
```
→ `no-floating-promises`, `no-unnecessary-condition`, `restrict-template-expressions`, `prefer-nullish-coalescing`, `prefer-optional-chain`, `array-type`, etc.

**Size / complexity / arity ceilings** (tightened from `eslint.configs.all` defaults):
| Rule | Was (default) | Now |
|---|---|---|
| `max-lines` | 300 | 200 |
| `max-lines-per-function` | 50 | 20 |
| `max-statements` | 10 | 10 (explicit) |
| `complexity` | 20 | 10 |
| `max-depth` | 4 | 3 |
| `max-nested-callbacks` | 10 | 3 |
| `max-params` | 3 | 3 (explicit) |

**Vue**: `require-explicit-emits`, `no-mutating-props`, `no-unused-refs`, `no-useless-v-bind`, `no-v-html`.
**Other**: `no-void { allowAsStatement: true }` (permits the `void`-promise idiom while banning the operator elsewhere), `caughtErrorsIgnorePattern`.

## Code fixes (the new rules caught these in existing `src`)
- `void` on intentional fire-and-forget promises — SocialLogin, utils, Languages, MenuList, MyPage.
- `typeof lang === "string"` guard for the `string | string[]` route param — i18n/utils.
- `Array<RouteRecordRaw>` → `RouteRecordRaw[]` — router.
- Extracted `buildLangPath` / `watchAuthState` so both `setup()` stay < 20 lines (also removed a ternary, since `no-ternary` is on).

## Verification
`yarn lint` ✅ · `yarn build` (vue-tsc + vite) ✅.

## Follow-up (not in this PR)
`functions/eslint.config.mjs` is still just `recommended` + `no-explicit-any: off`. Say the word and I'll give it the same treatment separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)