### PR TITLE
chore: tighten functions eslint for compact, DRY code

### DIFF
--- a/functions/eslint.config.mjs
+++ b/functions/eslint.config.mjs
@@ -1,17 +1,20 @@
 import eslint from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
+import sonarjs from "eslint-plugin-sonarjs";
 import eslintConfigPrettier from "eslint-config-prettier";
 
 export default [
   {
-    files: ["src/**/*.{js,ts,yaml,yml,json}"],
+    files: ["src/**/*.ts"],
   },
   {
-    ignores: ["lib/**/*", "*.ts"],
+    ignores: ["lib/**/*", "*.ts", "eslint.config.mjs"],
   },
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...tseslint.configs.stylisticTypeChecked,
+  sonarjs.configs.recommended,
   {
     languageOptions: {
       globals: {
@@ -20,20 +23,46 @@ export default [
       },
       ecmaVersion: "latest",
       sourceType: "module",
+      parserOptions: {
+        project: "./tsconfig.json",
+      },
     },
     rules: {
       indent: ["error", 2],
+
+      // Firebase Functions + Express/Hono deal in untyped request bodies and a
+      // CommonJS require() loader, so `any` and the no-unsafe-* family fire on the
+      // IO boundary with little value. Relaxed here; the app side stays strict.
       "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
           argsIgnorePattern: "^__",
           varsIgnorePattern: "^__",
+          caughtErrorsIgnorePattern: "^__",
         },
       ],
       "linebreak-style": ["error", "unix"],
       quotes: ["error", "double"],
       semi: ["error", "always"],
+      "no-void": ["error", { allowAsStatement: true }],
+
+      // Compact & DRY: hard ceilings on size, nesting, complexity, and arity
+      "max-lines": ["error", { max: 200, skipBlankLines: true, skipComments: true }],
+      "max-lines-per-function": ["error", { max: 20, skipBlankLines: true, skipComments: true }],
+      "max-statements": ["error", 10],
+      complexity: ["error", 10],
+      "max-depth": ["error", 3],
+      "max-nested-callbacks": ["error", 3],
+      "max-params": ["error", 3],
+
+      "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
     },
   },
   eslintConfigPrettier,

--- a/functions/src/functions/server/express.ts
+++ b/functions/src/functions/server/express.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-export const hello_response = async (req: express.Request, res: express.Response) => {
+export const hello_response = (req: express.Request, res: express.Response) => {
   res.json({ message: "hello" });
 };
 
@@ -13,7 +13,7 @@ export const stream_response = async (req: express.Request, res: express.Respons
   res.setHeader("Cache-Control", "no-cache, no-transform");
   res.setHeader("X-Accel-Buffering", "no");
 
-  for await (const num of ["1", "2", "3", "4", "5"]) {
+  for (const num of ["1", "2", "3", "4", "5"]) {
     res.write(num + "\n");
     await sleep(1000);
   }
@@ -24,7 +24,10 @@ export const stream_response = async (req: express.Request, res: express.Respons
 };
 
 export const app = express();
+app.disable("x-powered-by");
 app.use(express.json());
 app.get("/api/hello", hello_response);
 app.get("/v2_api/hello", hello_response);
-app.get("/v2_api/stream", stream_response);
+app.get("/v2_api/stream", (req, res) => {
+  void stream_response(req, res);
+});

--- a/functions/src/functions/server/hono.ts
+++ b/functions/src/functions/server/hono.ts
@@ -2,28 +2,23 @@ import { Hono } from "hono";
 import { Request as FunctionRequest } from "firebase-functions/v2/https";
 import { Response } from "express";
 
+const toFetchRequest = (req: FunctionRequest) => {
+  const url = new URL(`${req.protocol}://${req.hostname}${req.url}`);
+  const headers = new Headers();
+  Object.keys(req.headers).forEach((k) => {
+    headers.set(k, req.headers[k] as string);
+  });
+  if (["GET", "HEAD"].includes(req.method)) {
+    return new Request(url, { headers, method: req.method });
+  }
+  const body = req.body;
+  const payload = typeof body === "string" ? body : JSON.stringify(body ?? {});
+  return new Request(url, { headers, method: req.method, body: payload });
+};
+
 const handle = (app: Hono<any>) => {
   return async (req: FunctionRequest, resp: Response) => {
-    const url = new URL(`${req.protocol}://${req.hostname}${req.url}`);
-
-    const headers = new Headers();
-
-    Object.keys(req.headers).forEach((k) => {
-      headers.set(k, req.headers[k] as string);
-    });
-    const body = req.body;
-
-    const newRequest = ["GET", "HEAD"].includes(req.method)
-      ? new Request(url, {
-          headers,
-          method: req.method,
-        })
-      : new Request(url, {
-          headers,
-          method: req.method,
-          body: typeof body === "string" ? body : JSON.stringify(body || {}),
-        });
-    const res = await app.fetch(newRequest);
+    const res = await app.fetch(toFetchRequest(req));
     resp.json(await res.json());
   };
 };

--- a/functions/src/functions/server/streaming.ts
+++ b/functions/src/functions/server/streaming.ts
@@ -4,11 +4,10 @@ export const sleep = async (milliseconds: number) => {
   return await new Promise((resolve) => setTimeout(resolve, milliseconds));
 };
 export const streamingFunc = async (request: CallableRequest, response?: CallableResponse) => {
-  for await (const num of ["1", "2", "3", "4", "5"]) {
-    // res.write(num + "\n");
-    response?.sendChunk({ num });
+  for (const num of ["1", "2", "3", "4", "5"]) {
+    void response?.sendChunk({ num });
     await sleep(1000);
   }
-  
-  return {num: "12334"};
+
+  return { num: "12334" };
 };


### PR DESCRIPTION
## Summary
Companion to #68 (root/app config). Brings **`functions/eslint.config.mjs`** from a bare `recommended` setup up to a strict, type-aware config, plus the code fixes needed for the tracked `functions/src` to pass. Modelled on your `mulmocast-app` Node approach.

## Items to Confirm / Review
- **Why not identical to the app side (#68)**: functions is Node / firebase-functions / HTTP-adapter code, not Vue app code. It legitimately uses ternaries and untyped request bodies, so I did **not** use `eslint.configs.all`, kept `no-explicit-any` **off** (as it deliberately was), and relaxed the **`no-unsafe-*`** family at the IO boundary (require() loader + `req.body: any`). The valuable type-aware rules stay on. Confirm this Node-appropriate stance, or say and I'll push it harder (would mean typing the firebase/express IO layer).
- **Untracked scratch files**: `functions/src/{aa.ts, functions/aaa.ts, wrappers/func.ts, wrappers/firebase.ts}` are your local WIP (not committed). They will now **fail `yarn --cwd functions lint` locally** until you finish/remove them, but **CI is unaffected** (fresh checkout only sees tracked files, which pass). I did not touch them.
- **`stream_response` route wrapper**: async handler wrapped as `(req, res) => { void stream_response(req, res); }` to satisfy `no-misused-promises`. Confirm that's the shape you want (vs. an express async wrapper util).

## Config changes (`functions/eslint.config.mjs`)
- `recommended` → `strictTypeChecked` + `stylisticTypeChecked` (+ `parserOptions.project`) + `sonarjs.recommended`.
- Same ceilings as #68: `max-lines` 200, `max-lines-per-function` 20, `max-statements` 10, `complexity` 10, `max-depth` 3, `max-nested-callbacks` 3, `max-params` 3.
- `no-explicit-any` off + `no-unsafe-*` off (documented IO-boundary rationale); `no-void { allowAsStatement: true }`; `caughtErrorsIgnorePattern`.
- Ignore `eslint.config.mjs` itself (not in tsconfig → type-aware parse error).

## Code fixes (new rules caught real issues in tracked `src`)
| File | Fix | Rule |
|---|---|---|
| `functions/server/express.ts` | drop needless `async` on `hello_response` | `require-await` |
| | `for await` over a plain array → `for` | `await-thenable` |
| | `app.disable("x-powered-by")` | `sonarjs/x-powered-by` |
| | wrap async stream handler → void-returning route fn | `no-misused-promises` |
| `functions/server/hono.ts` | extract `toFetchRequest()` (handler < 20 lines) | `max-lines-per-function` |
| | `body \|\| {}` → `body ?? {}` | `prefer-nullish-coalescing` |
| `functions/server/streaming.ts` | `for await` → `for`; `void` the fire-and-forget `sendChunk` | `await-thenable`, `no-floating-promises` |

## Verification
- Lint of **tracked** `functions/src` (what CI runs): exit 0 ✅
- `yarn --cwd functions build` (tsc) ✅

Depends on nothing; independent of #68 (touches only `functions/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)